### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/drkNsubuga/PharmaSpot/security/code-scanning/38](https://github.com/drkNsubuga/PharmaSpot/security/code-scanning/38)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the provided workflow, the minimal permissions required are `contents: read`, as the workflow only checks out the repository, installs dependencies, and builds the project. No write operations are necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `release` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
