### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/drkNsubuga/PharmaSpot/security/code-scanning/39](https://github.com/drkNsubuga/PharmaSpot/security/code-scanning/39)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout` step requires `contents: read` to access the repository.
- The `npm run publish` step likely requires `contents: write` to publish changes.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as this workflow does not have multiple jobs requiring different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
